### PR TITLE
fix: use OPENGRAPH_APP_ID in installer and remove debug log spam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opengraph-io-mcp",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengraph-io-mcp",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -242,7 +242,7 @@ function generateServerConfig(appId: string): McpServerConfig {
         command: "npx",
         args: ["-y", "opengraph-io-mcp"],
         env: {
-            APP_ID: appId,
+            OPENGRAPH_APP_ID: appId,
         },
     };
 }
@@ -264,7 +264,7 @@ function generateVSCodeConfig(_appId: string): McpConfig {
                 command: "npx",
                 args: ["-y", "opengraph-io-mcp"],
                 env: {
-                    APP_ID: "${input:opengraph-app-id}",
+                    OPENGRAPH_APP_ID: "${input:opengraph-app-id}",
                 },
             },
         },

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -66,7 +66,7 @@ export const createServer = () => {
 
     let subscriptions: Set<string> = new Set();
     let subsUpdateInterval: NodeJS.Timeout | undefined;
-    let stdErrUpdateInterval: NodeJS.Timeout | undefined;
+    let logLevel: LoggingLevel = "debug";
 
     // Set up update interval for subscribed resources
     subsUpdateInterval = setInterval(() => {
@@ -77,49 +77,6 @@ export const createServer = () => {
             });
         }
     }, 10000);
-
-    let logLevel: LoggingLevel = "debug";
-    let logsUpdateInterval: NodeJS.Timeout | undefined;
-    const messages = [
-        { level: "debug", data: "Debug-level message" },
-        { level: "info", data: "Info-level message" },
-        { level: "notice", data: "Notice-level message" },
-        { level: "warning", data: "Warning-level message" },
-        { level: "error", data: "Error-level message" },
-        { level: "critical", data: "Critical-level message" },
-        { level: "alert", data: "Alert level-message" },
-        { level: "emergency", data: "Emergency-level message" },
-    ];
-
-    const isMessageIgnored = (level: LoggingLevel): boolean => {
-        const currentLevel = messages.findIndex((msg) => logLevel === msg.level);
-        const messageLevel = messages.findIndex((msg) => level === msg.level);
-        return messageLevel < currentLevel;
-    };
-
-    // Set up update interval for random log messages
-    logsUpdateInterval = setInterval(() => {
-        let message = {
-            method: "notifications/message",
-            params: messages[Math.floor(Math.random() * messages.length)],
-        };
-        if (!isMessageIgnored(message.params.level as LoggingLevel))
-            server.notification(message);
-    }, 20000);
-
-
-    // Set up update interval for stderr messages
-    stdErrUpdateInterval = setInterval(() => {
-        const shortTimestamp = new Date().toLocaleTimeString([], {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit'
-        });
-        server.notification({
-            method: "notifications/stderr",
-            params: { content: `${shortTimestamp}: A stderr message` },
-        });
-    }, 30000);
 
     // Helper method to request sampling from client
     const requestSampling = async (
@@ -670,8 +627,6 @@ This will create a transparent PNG icon ready for use in your application.`,
 
     const cleanup = async () => {
         if (subsUpdateInterval) clearInterval(subsUpdateInterval);
-        if (logsUpdateInterval) clearInterval(logsUpdateInterval);
-        if (stdErrUpdateInterval) clearInterval(stdErrUpdateInterval);
     };
 
     return { server, cleanup };


### PR DESCRIPTION
## Summary

Two fixes for issues discovered during MCP client debugging:

### 1. Installer env var mismatch
The installer was writing `APP_ID` to the MCP config, but error messages and documentation reference `OPENGRAPH_APP_ID`. Changed to use `OPENGRAPH_APP_ID` for consistency.

**Files changed:** `src/installer.ts`

### 2. Debug log spam removal  
The server was emitting random log messages (debug, info, warning, error, critical, alert, emergency) every 20 seconds and stderr messages every 30 seconds. This was clearly test/debug code that shouldn't be in production - it confused users and cluttered MCP client logs.

**Removed:**
- `logsUpdateInterval` - random log message spam
- `stdErrUpdateInterval` - periodic stderr spam
- Related helper functions and message arrays

**Kept:**
- `SetLevelRequestSchema` handler (valid MCP functionality)
- `logLevel` variable for the handler

**Files changed:** `src/mcp.ts`

## Testing
- [x] `npm run build` succeeds
- [ ] Manual test with Cursor after republish