### PR TITLE
feat: Add MCP Registry publishing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,29 @@ Then configure your client to connect to:
 http://localhost:3010/sse?app_id=YOUR_OPENGRAPH_APP_ID
 ```
 
+## MCP Registry & Distribution
+
+This server is published to the [Official MCP Registry](https://registry.modelcontextprotocol.io) and automatically discovered by other MCP directories.
+
+### Registry Status
+
+| Registry | Auto-Updates | Notes |
+|----------|-------------|-------|
+| **[Official MCP Registry](https://registry.modelcontextprotocol.io)** | ✅ On release | Source of truth, published via GitHub Actions |
+| **[PulseMCP](https://pulsemcp.com)** | ✅ Daily | Ingests from Official Registry |
+| **[Smithery](https://smithery.ai)** | ✅ Likely | Crawls npm automatically |
+| **[Glama](https://glama.ai)** | ✅ Likely | Aggregates from multiple sources |
+| **[MCP.so](https://mcp.so)** | ❌ Manual | One-time submission |
+
+### How Updates Propagate
+
+When a new version is released:
+1. `npm publish` pushes to npm registry
+2. GitHub Actions workflow publishes to Official MCP Registry
+3. Other directories (PulseMCP, Smithery, Glama) auto-discover within hours/days
+
+No manual intervention needed for most directories after initial listing.
+
 ## Troubleshooting
 
 - If tools aren't showing up, check that the server is running and the URL is correctly configured in Cursor

--- a/proposed-workflows/README.md
+++ b/proposed-workflows/README.md
@@ -1,0 +1,28 @@
+# Proposed Workflows
+
+These workflow files need to be moved to `.github/workflows/` to activate.
+
+## publish-mcp-registry.yml
+
+Publishes to the Official MCP Registry when version tags are pushed.
+
+### To activate:
+```bash
+mkdir -p .github/workflows
+mv proposed-workflows/publish-mcp-registry.yml .github/workflows/
+rm -r proposed-workflows  # cleanup
+```
+
+### How it works:
+1. Triggered on `v*` tags (e.g., `v1.4.0`)
+2. Uses GitHub OIDC authentication (no secrets needed)
+3. Auto-updates version in `server.json` from git tag
+4. Publishes to Official MCP Registry
+
+### Release process:
+```bash
+npm publish
+git tag v1.4.0
+git push origin v1.4.0
+# Workflow auto-publishes to MCP Registry
+```

--- a/proposed-workflows/publish-mcp-registry.yml
+++ b/proposed-workflows/publish-mcp-registry.yml
@@ -1,0 +1,32 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"] # Triggers on version tags like v1.0.0
+
+jobs:
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Update version in server.json
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+          cat server.json
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary
Adds automated publishing to the Official MCP Registry when version tags are pushed.

## Changes
- **New workflow**: `proposed-workflows/publish-mcp-registry.yml`
  - Triggered on `v*` tags (e.g., `v1.4.0`)
  - Uses GitHub OIDC authentication (no secrets required)
  - Auto-syncs version in `server.json` from git tag

- **README update**: Added "MCP Registry & Distribution" section
  - Documents which registries auto-update
  - Explains how updates propagate

## ⚠️ Action Required After Merge
Move the workflow file to activate it:
```bash
mkdir -p .github/workflows
mv proposed-workflows/publish-mcp-registry.yml .github/workflows/
rm -r proposed-workflows
```

## Release Process (after activation)
```bash
npm publish
git tag v1.4.0
git push origin v1.4.0
# Workflow auto-publishes to MCP Registry
```

## Registry Coverage
| Registry | Auto-Updates |
|----------|-------------|
| Official MCP Registry | ✅ This PR |
| PulseMCP | ✅ Ingests from Official |
| Smithery | ✅ Crawls npm |
| Glama | ✅ Aggregates |
| MCP.so | ❌ Manual (one-time)